### PR TITLE
Allow bri / sat 0-255 range

### DIFF
--- a/PoSHue.ps1
+++ b/PoSHue.ps1
@@ -393,9 +393,9 @@ Class HueLight : HueFactory {
     [ValidateLength(20, 50)][string] $APIKey
     [ValidateLength(1, 2000)][string] $JSON
     [bool] $On
-    [ValidateRange(1, 254)][int] $Brightness
+    [ValidateRange(0, 255)][int] $Brightness
     [ValidateRange(0, 65535)][int] $Hue
-    [ValidateRange(0, 254)][int] $Saturation
+    [ValidateRange(0, 255)][int] $Saturation
     [ValidateRange(153, 500)][int] $ColourTemperature
     [hashtable] $XY = @{ x = $null; y = $null }    
     [bool] $Reachable
@@ -1124,9 +1124,9 @@ Class HueGroup : HueFactory {
     [ValidateLength(20, 50)][string] $APIKey
     [ValidateLength(1, 2000)][string] $JSON
     [bool] $On
-    [ValidateRange(1, 254)][int] $Brightness
+    [ValidateRange(0, 255)][int] $Brightness
     [ValidateRange(0, 65535)][int] $Hue
-    [ValidateRange(0, 254)][int] $Saturation
+    [ValidateRange(0, 255)][int] $Saturation
     [ValidateRange(153, 500)][int] $ColourTemperature
     [hashtable] $XY = @{ x = $null; y = $null }
     [ColourMode] $ColourMode


### PR DESCRIPTION
I definitely have some bulbs that return 255 brightness. These aren't ZLL profile so I can't put them on an actual Hue Bridge to see if it would mangle the value to 254.

```
    "8": {
        "etag": "0331c26bcc0b370b77e746e8e8247f8c",
        "hascolor": false,
        "manufacturername": "sengled",
        "modelid": "E11-G13",
        "name": "Patio Left",
        "state": {
            "alert": "none",
            "bri": 255,
            "on": false,
            "reachable": true
        },
        "swversion": "00000003",
        "type": "Dimmable light",
        "uniqueid": "b0:ce:18:14:03:0d:78:86-01"
    },
    "9": {
        "etag": "0331c26bcc0b370b77e746e8e8247f8c",
        "hascolor": false,
        "manufacturername": "sengled",
        "modelid": "E11-G13",
        "name": "Patio Right",
        "state": {
            "alert": "none",
            "bri": 255,
            "on": false,
            "reachable": true
        },
        "swversion": "00000003",
        "type": "Dimmable light",
        "uniqueid": "b0:ce:18:14:03:0d:6b:18-01"
    },
```