### PR TITLE
Colormode is not returned by all lights

### DIFF
--- a/PoSHue.ps1
+++ b/PoSHue.ps1
@@ -537,7 +537,8 @@ Class HueLight : HueFactory {
 
         $this.Hue = $Status.state.hue
         $this.Saturation = $Status.state.sat
-        if(Get-Member -inputobject $Status.state -name "colormode" -Membertype Properties) {                                                           
+        
+        if (Get-Member -InputObject $Status.state -Name "colormode" -MemberType Properties) {                                                           
             $this.ColourMode = $Status.state.colormode
 
             # This is for compatibility reasons on Philips Ambient Lights
@@ -545,8 +546,9 @@ Class HueLight : HueFactory {
                 $this.XY.x = $Status.state.xy[0]
                 $this.XY.y = $Status.state.xy[1]
             }
-        } else {
-                $this.ColourMode = 'none'
+        }
+        else {
+            $this.ColourMode = 'none'
         }
 
         If ($Status.state.ct) {

--- a/PoSHue.ps1
+++ b/PoSHue.ps1
@@ -536,12 +536,14 @@ Class HueLight : HueFactory {
 
         $this.Hue = $Status.state.hue
         $this.Saturation = $Status.state.sat
-        $this.ColourMode = $Status.state.colormode
+        if(Get-Member -inputobject $Status.state -name "colormode" -Membertype Properties) {                                                           
+            $this.ColourMode = $Status.state.colormode
 
-        # This is for compatibility reasons on Philips Ambient Lights
-        if ($Status.state.colormode -eq "xy") {
-            $this.XY.x = $Status.state.xy[0]
-            $this.XY.y = $Status.state.xy[1]
+            # This is for compatibility reasons on Philips Ambient Lights
+            if ($Status.state.colormode -eq "xy") {
+                $this.XY.x = $Status.state.xy[0]
+                $this.XY.y = $Status.state.xy[1]
+            }
         }
 
         If ($Status.state.ct) {

--- a/PoSHue.ps1
+++ b/PoSHue.ps1
@@ -7,6 +7,7 @@ Enum LightState {
 
 Enum ColourMode {
     # Defines the colour modes that can be set on the light.
+    none
     xy
     ct
     hs
@@ -544,6 +545,8 @@ Class HueLight : HueFactory {
                 $this.XY.x = $Status.state.xy[0]
                 $this.XY.y = $Status.state.xy[1]
             }
+        } else {
+                $this.ColourMode = 'none'
         }
 
         If ($Status.state.ct) {


### PR DESCRIPTION
From the Hue API docs, colormode is only present when the light supports at least one of the values.

```
    "30": {
        "etag": "c9ff1f1e8ede7ad1d047a88294f0ddbc",
        "hascolor": false,
        "manufacturername": "CREE",
        "modelid": "Connected A-19 60W Equivalent",
        "name": "ktch1",
        "state": {
            "alert": "none",
            "bri": 254,
            "on": false,
            "reachable": true
        },
        "swversion": "500             ",
        "type": "Dimmable light",
        "uniqueid": "e2:0d:b9:ff:fe:04:cf:90-0a"
    }
```